### PR TITLE
Change custom-css to customCss

### DIFF
--- a/src/make-shins.js
+++ b/src/make-shins.js
@@ -28,7 +28,7 @@ d('Rendering shins')
 shins.render(
   markdownString,
   {
-    customCss: program['custom-css'],
+    customCss: program.customCss,
     inline: program.inline,
     minify: program.minify
   },
@@ -57,10 +57,10 @@ shins.render(
         )
         fs.writeFileSync(path.join(program.output, 'index.html'), html)
 
-        if (program['custom-css']) {
+        if (program.customCss) {
           d('Copying custom CSS')
           fs.copySync(
-            program['custom-css'],
+            program.customCss,
             path.join(program.output, '/pub/css')
           )
         }


### PR DESCRIPTION
To match the commander API, access the option using camelCase. Without this change, customCss is never passed into shins.